### PR TITLE
Rewrite server as Flask API

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -30,3 +30,5 @@ typing_extensions==4.14.0
 uvicorn==0.34.3
 websockets==15.0.1
 gunicorn
+Flask==3.1.0
+


### PR DESCRIPTION
## Summary
- replace FastMCP ASGI server with Flask API implementation
- expose `/search` and `/fetch/<id>` endpoints
- add Flask to project requirements

## Testing
- `python -m py_compile app.py`
- `pip install -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_687e1434c534832ab85024bb4d06b5e0